### PR TITLE
add the delete post action

### DIFF
--- a/lib/grapevine/posts.ex
+++ b/lib/grapevine/posts.ex
@@ -2,8 +2,6 @@ defmodule Grapevine.Posts do
   alias Grapevine.Post
   alias Grapevine.Repo
 
-  # alias Grapevine.Accounts
-
   def update(changeset, attrs) do
     changeset
     |> Post.changeset(attrs)
@@ -11,12 +9,15 @@ defmodule Grapevine.Posts do
   end
 
   def create(attrs, user_id) do
-    # user = Accounts.get_user!(user_id)
     attrs = Map.put(attrs, "user_id", user_id)
 
     %Post{}
     |> Post.changeset(attrs)
     |> Repo.insert()
+  end
+
+  def delete(id) do
+    Repo.delete(%Post{id: id})
   end
 
   def show_all() do

--- a/lib/grapevine_web/live/post_live.ex
+++ b/lib/grapevine_web/live/post_live.ex
@@ -1,12 +1,12 @@
 defmodule GrapevineWeb.PostLive do
   use GrapevineWeb, :live_view
 
-  alias Grapevine.Accounts
+  alias Grapevine.{Accounts, Posts}
 
   # this will run when "user_token" is present in the session map,
   # which will happen if there is a logged-in user
   def mount(_params, %{"user_token" => token}, socket) do
-    posts = Grapevine.Posts.show_all()
+    posts = Posts.show_all()
     user = Accounts.get_user_by_session_token(token)
     {:ok, assign(socket, posts: posts, current_user: user, post_id: nil)}
   end
@@ -15,7 +15,7 @@ defmodule GrapevineWeb.PostLive do
   # still refer to `@current_user` assignment in the template to check its value.
   # If there is no such key in socket assigns at all, the template will through an error. You can double check me on this though.
   def mount(_params, _session, socket) do
-    posts = Grapevine.Posts.show_all()
+    posts = Posts.show_all()
     {:ok, assign(socket, posts: posts, current_user: nil, post_id: nil)}
   end
 
@@ -25,5 +25,15 @@ defmodule GrapevineWeb.PostLive do
 
   def handle_params(_, _, socket) do
     {:noreply, socket}
+  end
+
+  def handle_event("delete-post", %{"post-id" => id}, socket) do
+    id
+    |> String.to_integer()
+    |> Posts.delete()
+
+    posts = Posts.show_all()
+
+    {:noreply, assign(socket, posts: posts)}
   end
 end

--- a/lib/grapevine_web/live/post_live.html.leex
+++ b/lib/grapevine_web/live/post_live.html.leex
@@ -10,19 +10,14 @@
     <h2>Posts</h2>
     <%= for p <- @posts do %>
         <div class="flex text-red-500 flex-col">
-            <a href=<%= p.content %> target="_blank">
-                <%= p.title %>
-            </a>
+            <%= link p.title, to: p.content, target: "_blank" %>
             |
             <%= if @current_user do %>
-              <%= live_patch "edit", to: Routes.post_path(@socket, :edit, p.id) %>
-              <%= if @post_id != nil and @live_action == :edit and @post_id == to_string(p.id)  do %>
-                <%= live_component PostLive.FormComponent, 
-                    post: p,
-                    id: "post_#{p.id}", 
-                    current_user: @current_user 
-                  %>
-              <% end %>
+                <%= live_patch "edit", to: Routes.post_path(@socket, :edit, p.id) %>
+                <%= if @post_id != nil and @live_action == :edit and @post_id == to_string(p.id)  do %>
+                    <%= live_component PostLive.FormComponent, post: p, id: "post_#{p.id}", current_user: @current_user %>
+                <% end %>
+                | <%= link "delete", to: "#", phx_click: "delete-post", phx_value_post_id: p.id, data: [confirm: "Are you sure?"] %>
             <% end %>
         </div>
     <% end %>

--- a/test/grapevine/posts_test.exs
+++ b/test/grapevine/posts_test.exs
@@ -4,6 +4,23 @@ defmodule Grapevine.PostsTest do
   alias Grapevine.Post
   alias Grapevine.Posts
 
+  describe "delete/1" do
+    test "successfully deleted an existing post" do
+      %{id: user_id} = user_fixture()
+
+      {:ok, %Post{id: post_id}} =
+        Posts.create(%{"title" => "my first post", "content" => "http://google.com"}, user_id)
+
+      assert {:ok, %Post{id: ^post_id}} = Posts.delete(post_id)
+    end
+
+    test "failure to delete a non-existent post" do
+      assert_raise Ecto.StaleEntryError, fn ->
+        Posts.delete(0)
+      end
+    end
+  end
+
   describe "update/2" do
     test "successfully updates an existing post" do
       %{id: id} = user_fixture()


### PR DESCRIPTION
## Checklist
- remove comments code inside of the posts context.
- add the delete function inside of the posts context, and just received
  the post id and create a Post struct/schema and called the Repo
  delete.
- add the handle_event with delete-post action, received a post-id with
  id as a params and a socket, pipe the post id to convert string to
  integer, and pipe through the delete function in posts context, and
  call all the posts again to the database.
  **maybe remove this posts to the posts socket assigns**.
- use the Phoenix link helper macro to implement the click event and
  called the delete-post after confirm the deleted.
- use the Phoenix link helper macro to open the post created, instead of
  use the a HTML tag.
- add test to cover the delete action with two scenarios, the first owns
  create a new post and deleted after, and the second owns try to delete
  an non-exist post and assert raise with that.

---

![screenshot-2021-08-26-21-11-09](https://user-images.githubusercontent.com/1036970/131051848-29e9525e-5812-4649-ad28-8bbe2568e6d2.png)