### PR TITLE
add dummy data to create users and posts

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,5 @@
+require Ecto.Query
+alias Grapevine.Repo
+alias Grapevine.Accounts.User
+alias Grapevine.{Like, Post}
+alias Grapevine.{Accounts, Posts}

--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ Setup the project with `mix setup`.
 Start Phoenix endpoint with `mix phx.server`.
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+
+### Dummy Data
+
+Add instructions into `priv/repo/seeds.exs` to delete dummy users and posts and create all dummy users and posts, when its run `mix run priv/repo/seeds.exs` or `mix setup`.
+
+| e-mail                  | password     |
+| ----------------------- | ------------ |
+| user.elixir@example.com | passwordpass |
+| user.ruby@example.com   | passwordpass |

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,94 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+require Ecto.Query
+
+alias Grapevine.Repo
+alias Grapevine.Accounts.User
+alias Grapevine.Post
+
+#############################################
+# USERS
+# ##########################################
+
+# user attrs
+user_attrs = [
+  %{email: "user.elixir@example.com", password: "passwordpass"},
+  %{email: "user.ruby@example.com", password: "passwordpass"}
+]
+
+# fetch user email
+user_emails = Enum.map(user_attrs, &Map.get(&1, :email))
+
+# delete users
+(u in User)
+|> Ecto.Query.from(where: u.email in ^user_emails)
+|> Repo.delete_all()
+
+# create users
+created_users =
+  user_attrs
+  |> Enum.map(fn attrs ->
+    %User{}
+    |> User.registration_changeset(attrs)
+    |> Repo.insert!()
+  end)
+
+#############################################
+# POSTS
+# ##########################################
+
+# split users
+[first_user, last_user] = created_users
+
+# post attrs
+post_attrs = [
+  %{
+    title: "Programming Phoenix LiveView - Book",
+    content: "https://pragprog.com/titles/liveview/programming-phoenix-liveview/",
+    user_id: first_user.id
+  },
+  %{
+    title: "Designing Elixir Systems with OTP - Book",
+    content: "https://pragprog.com/titles/jgotp/designing-elixir-systems-with-otp/",
+    user_id: first_user.id
+  },
+  %{
+    title: "Programming Phoenix 1.4 - Book",
+    content: "https://pragprog.com/titles/phoenix14/programming-phoenix-1-4/",
+    user_id: first_user.id
+  },
+  %{
+    title: "Agile Web Development with Rails 6 - Book",
+    content: "https://pragprog.com/titles/rails6/agile-web-development-with-rails-6/",
+    user_id: last_user.id
+  },
+  %{
+    title: "Docker for Rails Developers - Book",
+    content: "https://pragprog.com/titles/ridocker/docker-for-rails-developers/",
+    user_id: last_user.id
+  },
+  %{
+    title: "Rails 5 Test Prescription - Book",
+    content: "https://pragprog.com/titles/nrtest3/rails-5-test-prescriptions/",
+    user_id: last_user.id
+  }
+]
+
+# fetch post title
+post_titles = Enum.map(post_attrs, &Map.get(&1, :title))
+
+# delete posts
+(p in Post)
+|> Ecto.Query.from(where: p.title in ^post_titles)
+|> Repo.delete_all()
+
+# create posts
+_created_posts =
+  post_attrs
+  |> Enum.map(fn attrs ->
+    %Post{}
+    |> Post.changeset(attrs)
+    |> Repo.insert!()
+  end)


### PR DESCRIPTION
- It uses the seeds to delete the current and recreate dummy data.
  - users
  - posts
- Add a section to the README, with user mail and password to login.
- Add alias to Repo, User, Post, and Like for the IEx section.

---

Preview:
![screenshot-2021-09-03-09-41-29](https://user-images.githubusercontent.com/1036970/132007414-b9f1ccab-9e7c-4bc1-ac72-5ba10af5f7e2.png)
