### PR TITLE
add unlike post action

### DIFF
--- a/lib/grapevine_web/live/post_live.html.leex
+++ b/lib/grapevine_web/live/post_live.html.leex
@@ -14,7 +14,7 @@
 
             <%= live_component PostLive.LikesComponent, id: "#{p.id}_my_likes", current_user: @current_user, post: p %>
 
-            <%= if @current_user.id == p.user_id do %>
+            <%= if not is_nil(@current_user) and (@current_user.id == p.user_id) do %>
                 |
                 <%= live_patch "edit", to: Routes.post_path(@socket, :edit, p.id) %>
                 <%= if @post_id != nil and @live_action == :edit and @post_id == to_string(p.id)  do %>

--- a/lib/grapevine_web/live/post_live/likes_component.ex
+++ b/lib/grapevine_web/live/post_live/likes_component.ex
@@ -1,24 +1,25 @@
 defmodule PostLive.LikesComponent do
-
-
   use GrapevineWeb, :live_component
 
   def update(assigns, socket) do
-    {:ok, socket |> assign(assigns) }
+    {:ok, socket |> assign(assigns)}
   end
 
-  def handle_event("like_it", _, %{assigns: %{post: post, current_user: user}} = socket) do
-    Grapevine.Posts.create_like(%{user_id: user.id, post_id: post.id})
+  def handle_event("like", _, %{assigns: %{post: post, current_user: user}} = socket) do
+    Grapevine.Posts.like(%{user_id: user.id, post_id: post.id})
     post = Grapevine.Posts.get(post.id)
-    {:noreply, 
-      socket
-      |> assign(%{post: post})
-    }
 
-
-
+    {:noreply,
+     socket
+     |> assign(%{post: post})}
   end
 
+  def handle_event("unlike", _, %{assigns: %{post: post, current_user: user}} = socket) do
+    Grapevine.Posts.unlike(%{user_id: user.id, post_id: post.id})
+    post = Grapevine.Posts.get(post.id)
 
-
+    {:noreply,
+     socket
+     |> assign(%{post: post})}
+  end
 end

--- a/lib/grapevine_web/live/post_live/likes_component.html.leex
+++ b/lib/grapevine_web/live/post_live/likes_component.html.leex
@@ -1,8 +1,12 @@
 <div style="display:flex">
   <%= length @post.likes %>
   &nbsp
-  <%= if @current_user do%>
-    <%= link "like_it", to: "#",  phx_click: "like_it", phx_target: @myself %>
+
+  <%= if @current_user do %>
+    <%= if Enum.any?(@post.likes, fn %{user_id: user_id} -> user_id == @current_user.id end) do %>
+      <%= link "unlike", to: "#",  phx_click: "unlike", phx_target: @myself %>
+    <% else %>
+      <%= link "like", to: "#",  phx_click: "like", phx_target: @myself %>
+    <% end %>
   <% end %>
 </div>
-

--- a/test/grapevine/posts_test.exs
+++ b/test/grapevine/posts_test.exs
@@ -69,11 +69,12 @@ defmodule Grapevine.PostsTest do
         id
       )
 
-    test_posts = [post_one.id, post_two.id]
+    test_posts = Enum.sort([post_one.id, post_two.id])
 
     assert test_posts ==
              Posts.show_all()
              |> Enum.filter(fn post -> id == post.user_id end)
              |> Enum.map(fn post -> post.id end)
+             |> Enum.sort()
   end
 end

--- a/test/grapevine/posts_test.exs
+++ b/test/grapevine/posts_test.exs
@@ -69,7 +69,11 @@ defmodule Grapevine.PostsTest do
         id
       )
 
-    test_posts = [post_one, post_two]
-    assert test_posts == Posts.show_all()
+    test_posts = [post_one.id, post_two.id]
+
+    assert test_posts ==
+             Posts.show_all()
+             |> Enum.filter(fn post -> id == post.user_id end)
+             |> Enum.map(fn post -> post.id end)
   end
 end


### PR DESCRIPTION
Issue: https://github.com/groxio-learning/grapevine/issues/24

- Posts context: 
  - Add unlike and get_like function into posts context the `get_like`, received a map with `post_id` and `user_id`, and turn a map into a keyword list, and used it in a where condition to fetch data. The `unlike` function, received a map with `post_id`, and `used_id`, and pipe these through get_link and called a `Repo.one`, to pattern match with `%Grapevine.Like{}` schema, and if it does delete this data from database.
 - Posts and like live view template:
   - add another statement on if condition to ensure the current_user wasn't nil.
   - add a statement to show like or unlike link posts, it was necessary to write a nested if conditions.
     - the outsider validate if it has a current_user.
     - the insider validates has a like and match with the current_user and
post, to change between like or unlike link.
 - Add an unlike handle_event into like component.
 - Fix posts tests.