### PR TITLE
Like sort on initial press when stale

### DIFF
--- a/lib/grapevine_web/live/post_live.ex
+++ b/lib/grapevine_web/live/post_live.ex
@@ -36,7 +36,6 @@ defmodule GrapevineWeb.PostLive do
     end
   end
 
-
   def handle_params(_, _, socket) do
     {:noreply, socket}
   end
@@ -71,6 +70,7 @@ defmodule GrapevineWeb.PostLive do
   def sort_posts(posts, "likes", :desc) do
     Enum.sort_by(posts, fn p -> p.likes end) |> Enum.reverse()
   end
+
   def sort_posts(posts, "likes", :asc) do
     Enum.sort_by(posts, fn p -> p.likes end)
   end
@@ -78,10 +78,10 @@ defmodule GrapevineWeb.PostLive do
   def toggle_like_order(:asc) do
     :desc
   end
+
   def toggle_like_order(:desc) do
     :asc
   end
-
 
   def assign_like_order(socket, sort_by) do
     posts = sort_posts(socket.assigns.posts, sort_by, socket.assigns.like_order)

--- a/lib/grapevine_web/live/post_live/likes_component.ex
+++ b/lib/grapevine_web/live/post_live/likes_component.ex
@@ -9,7 +9,7 @@ defmodule PostLive.LikesComponent do
     Grapevine.Posts.like(%{user_id: user.id, post_id: post.id})
     post = Grapevine.Posts.get(post.id)
 
-    send self(), {:updated_post, post}
+    send(self(), {:updated_post, post})
 
     {:noreply, socket}
   end


### PR DESCRIPTION
We mostly fixed this issue during our last session. But as I was clicking around in the browser, it seems that when you unlike something and sort the first time w/o a refresh that the issue was still happening. cc: @herminiotorres @SophieDeBenedetto 