### PR TITLE
fixed bug where unlike wasn't sending message to update, also adding …

### DIFF
--- a/lib/grapevine_web/live/post_live/likes_component.ex
+++ b/lib/grapevine_web/live/post_live/likes_component.ex
@@ -9,7 +9,7 @@ defmodule PostLive.LikesComponent do
     Grapevine.Posts.like(%{user_id: user.id, post_id: post.id})
     post = Grapevine.Posts.get(post.id)
 
-    send(self(), {:updated_post, post})
+    Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:updated_post, post})
 
     {:noreply, socket}
   end
@@ -18,8 +18,8 @@ defmodule PostLive.LikesComponent do
     Grapevine.Posts.unlike(%{user_id: user.id, post_id: post.id})
     post = Grapevine.Posts.get(post.id)
 
-    {:noreply,
-     socket
-     |> assign(%{post: post})}
+    Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:updated_post, post})
+
+    {:noreply, socket}
   end
 end


### PR DESCRIPTION
…in pubsub broadcast for likes

This closes issue #35. PubSub was already setup for Post updates so we simply had to broadcast a new message when like/unlike was clicked. We also fixed the bug where unlike handle_event was not sending out the message to the process unlike events like we were doing in the like handle_event, this was immediately replaced with the PubSub broadcasts which gave us the same behavior but globally. 

There was only 2 of us (@herminiotorres) tonight so we didn't want to decide for the group what to do next. But we do have a [list of features](https://gist.github.com/SophieDeBenedetto/4127f6fc7112d3277b04f3493e4b7ee0#gistcomment-3784430) that we thought about when we started that we can pick from next week. I will also post to discord for review.