### PR TITLE
Add category to form to create a new post

### DIFF
--- a/lib/grapevine/posts.ex
+++ b/lib/grapevine/posts.ex
@@ -61,8 +61,11 @@ defmodule Grapevine.Posts do
     from l in Like, where: [user_id: ^user_id, post_id: ^post_id]
   end
 
-  def get_categories() do
-    Repo.all(from Category, select: [:name, :id])
+  def get_categories(fields \\  [:name, :id]) do
+    query =
+      from c in Category, select: map(c, ^fields)
+      
+      Repo.all(query)
   end
 
   def post_changeset(%{post: post}) do

--- a/lib/grapevine/posts.ex
+++ b/lib/grapevine/posts.ex
@@ -1,7 +1,7 @@
 defmodule Grapevine.Posts do
   import Ecto.Query
 
-  alias Grapevine.{Like, Post}
+  alias Grapevine.{Like, Post, Category}
   alias Grapevine.Repo
 
   def show_all do
@@ -59,6 +59,10 @@ defmodule Grapevine.Posts do
 
   def get_like(%{user_id: user_id, post_id: post_id} = _attrs) do
     from l in Like, where: [user_id: ^user_id, post_id: ^post_id]
+  end
+
+  def get_categories() do
+    Repo.all(from Category, select: [:name, :id])
   end
 
   def post_changeset(%{post: post}) do

--- a/lib/grapevine_web/live/post_live/form_component.ex
+++ b/lib/grapevine_web/live/post_live/form_component.ex
@@ -9,6 +9,7 @@ defmodule PostLive.FormComponent do
     {:ok,
      socket
      |> assign(assigns)
+     |> assign(:categories, Grapevine.Posts.get_categories())
      |> assign(:changeset, changeset)}
   end
 
@@ -18,6 +19,8 @@ defmodule PostLive.FormComponent do
   end
 
   def handle_event("save", %{"post" => post_params}, socket) do
+    IO.puts("PUT SELECT ID")
+    IO.inspect(post_params)
     post = Grapevine.Posts.create(post_params, socket.assigns.current_user.id)
     Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:post_created, post})
     {:noreply, push_redirect(socket, to: "/posts")}

--- a/lib/grapevine_web/live/post_live/form_component.html.leex
+++ b/lib/grapevine_web/live/post_live/form_component.html.leex
@@ -8,5 +8,8 @@
     Content: <%= text_input f, :content %>
   </label>
 
-  <%= submit "Submit"  %>
+  <label>
+    Category: <%= select f, :category_id, Enum.map(@categories, &{&1.name, &1.id}) %>
+  </label>
 
+  <%= submit "Submit"  %>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -16,6 +16,7 @@ alias Grapevine.Posts
 alias Grapevine.Accounts.User
 alias Grapevine.Like
 alias Grapevine.Post
+alias Grapevine.Category
 
 #############################################
 # USERS ATTRS
@@ -130,3 +131,38 @@ Repo.insert_all(Post, post_attrs)
 )
 |> Repo.all()
 |> Enum.map(&Posts.like/1)
+
+#############################################
+# CATEGORIES
+# ##########################################
+
+category_attrs = [
+  %{
+    name: "blog",
+    inserted_at: days_ago.(35),
+    updated_at: days_ago.(35)
+  },
+  %{
+    name: "video",
+    inserted_at: days_ago.(35),
+    updated_at: days_ago.(35)
+  },
+  %{
+    name: "book",
+    inserted_at: days_ago.(35),
+    updated_at: days_ago.(35)
+  },
+  %{
+    name: "course",
+    inserted_at: days_ago.(35),
+    updated_at: days_ago.(35)
+  },
+  %{
+    name: "podcast",
+    inserted_at: days_ago.(35),
+    updated_at: days_ago.(35)
+  }
+]
+
+# create categories
+Repo.insert_all(Category, category_attrs)


### PR DESCRIPTION
Added some categories into the db using the seed file. 
Update the form component to display the categories. ~Save is not implemented yet.~

To fix the issue we were having with select I looked at the https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#select/4, specifically the section about options coming from the database:

> If you want to select an option that comes from the database, such as a manager for a given project, you may write:
```ex
select(form, :manager_id, Enum.map(@managers, &{&1.name, &1.id}))
#=> <select id="manager_id" name="project[manager_id]">
#=>   <option value="1">Mary Jane</option>
#=>   <option value="2">John Doe</option>
#=> </select>
```
Also looked at [SO to see how to return categories](https://stackoverflow.com/a/48031112). We were on the right path, adding the `map` in the html/template was what was missing.


~**TODO**: need to save new posts with the categories to the database.~
No changes needed to make the save work, it just works.  Need to remove `IO.puts` from save.
